### PR TITLE
update team 5 and 10 plans and add business plan

### DIFF
--- a/plans.html
+++ b/plans.html
@@ -45,14 +45,14 @@ signup: true
                                 <!-- /price-block -->
                                 <div class="col-md-4 col-lg-4 bgrid">
                                     <div class="price-block primary">
-                                        <div class="top-part" data-info="USD $49 or $99 /mth">
+                                        <div class="top-part" data-info="USD $99 /mth">
                                             <h3 class="plan-title">Team</h3>
                                             <p class="price-txt">For small teams</p>
                                         </div>
                                         <div class="bottom-part">
                                             <p>Great for small development teams and start ups</p>
                                             <ul class="features">
-                                                <li>5 or 10 users</li>
+                                                <li>10 users</li>
                                                 <li>Unlimited contracts</li>
                                                 <li>Email support</li>
                                                 <li>Github and Google Login</li>
@@ -60,10 +60,7 @@ signup: true
                                             <p>Try us for <strong>FREE</strong> for the first 14 days</p>
                                         </div>
                                         <div class="row">
-                                            <a class="button large multiple first" href="javascript:void(0)" data-cb-type="checkout" data-cb-plan-id="team-5-plan" >Sign up for 5 users ($49)</a>
-                                        </div>
-                                        <div class="row">
-                                            <a class="button large multiple" href="javascript:void(0)" data-cb-type="checkout" data-cb-plan-id="team-10-plan" >Sign up for 10 users ($99)</a>
+                                            <a class="button large multiple" href="javascript:void(0)" data-cb-type="checkout" data-cb-plan-id="team-10-plan" >Sign up ($99)</a>
                                         </div>
                                     </div>
                                 </div>

--- a/plans.html
+++ b/plans.html
@@ -45,14 +45,14 @@ signup: true
                                 <!-- /price-block -->
                                 <div class="col-md-4 col-lg-4 bgrid">
                                     <div class="price-block primary">
-                                        <div class="top-part" data-info="USD $99 /mth">
+                                        <div class="top-part" data-info="USD $49 or $99 /mth">
                                             <h3 class="plan-title">Team</h3>
                                             <p class="price-txt">For small teams</p>
                                         </div>
                                         <div class="bottom-part">
                                             <p>Great for small development teams and start ups</p>
                                             <ul class="features">
-                                                <li>10 users</li>
+                                                <li>5 or 10 users</li>
                                                 <li>Unlimited contracts</li>
                                                 <li>Email support</li>
                                                 <li>Github and Google Login</li>
@@ -60,7 +60,10 @@ signup: true
                                             <p>Try us for <strong>FREE</strong> for the first 14 days</p>
                                         </div>
                                         <div class="row">
-                                            <a class="button large multiple" href="javascript:void(0)" data-cb-type="checkout" data-cb-plan-id="team-10-plan" >Sign up ($99)</a>
+                                            <a class="button large multiple first" href="javascript:void(0)" data-cb-type="checkout" data-cb-plan-id="team-5-plan" >Sign up for 5 users ($49)</a>
+                                        </div>
+                                        <div class="row">
+                                            <a class="button large multiple" href="javascript:void(0)" data-cb-type="checkout" data-cb-plan-id="team-10-plan" >Sign up for 10 users ($99)</a>
                                         </div>
                                     </div>
                                 </div>

--- a/plans.html
+++ b/plans.html
@@ -18,80 +18,77 @@ signup: true
                 </div>
     </section>
     <div class="container">
-      <section id="pricing">
-              <div class="cnt-pricing-bg">
-                  <div class="container">
-                      <h1>Plans &amp; Pricing</h1>
-                      <p class="top-txt">Options to suit teams of all sizes and needs</p>
-                      <div class="row pricing-content">
-                          <div class="pricing-tables col-md-12 col-lg-12 group">
-                              <div class="col-md-4 col-lg-4 bgrid">
-                                  <div class="price-block primary">
-                                      <div class="top-part"  data-info="FREE">
-                                          <h3 class="plan-title">Developers</h3>
-                                          <p class="price-txt">For individuals</p>
-                                      </div>
-                                      <div class="bottom-part">
-                                          <p>Designed to get you started and give us a try</p>
-                                          <ul class="features">
-                                              <li>1 user </li>
-                                              <li>Core features</li>
-                                              <li>5 contracts</li>
-                                          </ul>
-                                      </div>
-                                      <a class="button large" href="/register/">Get Started for free</a>
-                                  </div>
-                              </div>
-                              <!-- /price-block -->
-                              <div class="col-md-4 col-lg-4 bgrid">
-                                  <div class="price-block primary">
-                                      <div class="top-part" data-info="USD $29 or $49 /mth">
-                                          <h3 class="plan-title">Team</h3>
-                                          <p class="price-txt">For small teams</p>
-                                      </div>
-                                      <div class="bottom-part">
-                                          <p>Great for small development teams and start ups</p>
-                                          <ul class="features">
-                                              <li>5 or 10 users</li>
-                                              <li>Unlimited contracts</li>
-                                              <li>Premium User Experience</li>
-                                              <li>Email &amp; Chat support</li>
-                                          </ul>
-                                      </div>
-                                      <div class="row">
-                                          <a class="button large multiple first" href="javascript:void(0)" data-cb-type="checkout" data-cb-plan-id="team-5" >Sign up for 5 users ($29)</a>
-                                      </div>
-                                      <div class="row">
-                                          <a class="button large multiple" href="javascript:void(0)" data-cb-type="checkout" data-cb-plan-id="team-10" >Sign up for 10 users ($49)</a>
-                                      </div>
-                                  </div>
-                              </div>
-                              <!-- /price-block -->
-                              <div class="col-md-4 col-lg-4 bgrid">
-                                  <div class="price-block primary">
-                                      <div class="top-part"  data-info="USD $24 per user /mth">
-                                          <h3 class="plan-title">Business</h3>
-                                          <p class="price-txt">Contract testing at scale</p>
-                                      </div>
-                                      <div class="bottom-part">
-                                          <p>Support and features suited to larger teams</p>
-                                          <ul class="features">
-                                              <li>Swagger integration</li>
-                                              <li>SAML SSO support</li>
-                                              <li>Team collaboration features</li>
-                                              <li>Priority support</li>
-                                          </ul>
-                                      </div>
-                                      <a class="button large" href="mailto:hello@pactflow.io">Contact Us</a>
-                                  </div>
-                              </div>
-                          </div>
-                          <!-- /pricing-tables -->
-                      </div>
-                      <!-- /pricing-content -->
-                  </div>
-                  <!-- //.container-->
-              </div>
-              <!-- //.cnt-pricing-bg -->
-      </section>
+        <section id="pricing">
+                <div class="cnt-pricing-bg">
+                    <div class="container">
+                        <h1>Plans &amp; Pricing</h1>
+                        <p class="top-txt">Options to suit teams of all sizes and needs</p>
+                        <div class="row pricing-content">
+                            <div class="pricing-tables col-md-12 col-lg-12 group">
+                                <div class="col-md-4 col-lg-4 bgrid">
+                                    <div class="price-block primary">
+                                        <div class="top-part"  data-info="FREE">
+                                            <h3 class="plan-title">Developers</h3>
+                                            <p class="price-txt">For individuals</p>
+                                        </div>
+                                        <div class="bottom-part">
+                                            <p>Designed to get you started and give us a try</p>
+                                            <ul class="features">
+                                                <li>1 user </li>
+                                                <li>Core features</li>
+                                                <li>5 contracts</li>
+                                            </ul>
+                                        </div>
+                                        <a class="button large multiple" href="javascript:void(0)" data-cb-type="checkout" data-cb-plan-id="developer-plan" >Get started for free</a>
+                                    </div>
+                                </div>
+                                <!-- /price-block -->
+                                <div class="col-md-4 col-lg-4 bgrid">
+                                    <div class="price-block primary">
+                                        <div class="top-part" data-info="USD $99 /mth">
+                                            <h3 class="plan-title">Team</h3>
+                                            <p class="price-txt">For small teams</p>
+                                        </div>
+                                        <div class="bottom-part">
+                                            <p>Great for small development teams and start ups</p>
+                                            <ul class="features">
+                                                <li>10 users</li>
+                                                <li>Unlimited contracts</li>
+                                                <li>Email support</li>
+                                                <li>Github and Google Login</li>
+                                            </ul>
+                                            <p>Try us for <strong>FREE</strong> for the first 14 days</p>
+                                        </div>
+                                        <div class="row">
+                                            <a class="button large multiple" href="javascript:void(0)" data-cb-type="checkout" data-cb-plan-id="team-10-plan" >Sign up ($99)</a>
+                                        </div>
+                                    </div>
+                                </div>
+                                <!-- /price-block -->
+                                <div class="col-md-4 col-lg-4 bgrid">
+                                    <div class="price-block primary">
+                                        <div class="top-part"  data-info="USD $249 /mth">
+                                            <h3 class="plan-title">Business</h3>
+                                            <p class="price-txt">Contract testing at scale</p>
+                                        </div>
+                                        <div class="bottom-part">
+                                            <p>Support and features suited to larger teams</p>
+                                            <ul class="features">
+                                                <li>25 Users</li>
+                                                <li>SAML SSO support</li>
+                                                <li>Onboarding support</li>
+                                            </ul>
+                                        </div>
+                                        <a class="button large multiple" href="javascript:void(0)" data-cb-type="checkout" data-cb-plan-id="business-25-plan" >Sign up ($249)</a>
+                                    </div>
+                                </div>
+                            </div>
+                            <!-- /pricing-tables -->
+                        </div>
+                        <!-- /pricing-content -->
+                    </div>
+                    <!-- //.container-->
+                </div>
+                <!-- //.cnt-pricing-bg -->
+        </section>
     </div>

--- a/pricing.html
+++ b/pricing.html
@@ -39,51 +39,47 @@ signup: true
                                             <li>5 contracts</li>
                                         </ul>
                                     </div>
-                                    <a class="button large" href="/register/">Get Started for free</a>
+                                    <a class="button large multiple" href="javascript:void(0)" data-cb-type="checkout" data-cb-plan-id="developer-plan" >Get started for free</a>
                                 </div>
                             </div>
                             <!-- /price-block -->
                             <div class="col-md-4 col-lg-4 bgrid">
                                 <div class="price-block primary">
-                                    <div class="top-part" data-info="USD $29 or $49 /mth">
+                                    <div class="top-part" data-info="USD $99 /mth">
                                         <h3 class="plan-title">Team</h3>
                                         <p class="price-txt">For small teams</p>
                                     </div>
                                     <div class="bottom-part">
                                         <p>Great for small development teams and start ups</p>
                                         <ul class="features">
-                                            <li>5 or 10 users</li>
+                                            <li>10 users</li>
                                             <li>Unlimited contracts</li>
-                                            <li>Premium User Experience</li>
-                                            <li>Email &amp; Chat support</li>
-                                            <p>Try us for <strong>FREE</strong> for the first 30 days</p>
+                                            <li>Email support</li>
+                                            <li>Github and Google Login</li>
                                         </ul>
+                                        <p>Try us for <strong>FREE</strong> for the first 14 days</p>
                                     </div>
                                     <div class="row">
-                                        <a class="button large multiple first" href="javascript:void(0)" data-cb-type="checkout" data-cb-plan-id="team-5" >Sign up for 5 users ($29)</a>
-                                    </div>
-                                    <div class="row">
-                                        <a class="button large multiple" href="javascript:void(0)" data-cb-type="checkout" data-cb-plan-id="team-10" >Sign up for 10 users ($49)</a>
+                                        <a class="button large multiple" href="javascript:void(0)" data-cb-type="checkout" data-cb-plan-id="team-10-plan" >Sign up ($99)</a>
                                     </div>
                                 </div>
                             </div>
                             <!-- /price-block -->
                             <div class="col-md-4 col-lg-4 bgrid">
                                 <div class="price-block primary">
-                                    <div class="top-part"  data-info="USD $24 per user /mth">
+                                    <div class="top-part"  data-info="USD $249 /mth">
                                         <h3 class="plan-title">Business</h3>
                                         <p class="price-txt">Contract testing at scale</p>
                                     </div>
                                     <div class="bottom-part">
                                         <p>Support and features suited to larger teams</p>
                                         <ul class="features">
-                                            <li>Swagger integration</li>
+                                            <li>25 Users</li>
                                             <li>SAML SSO support</li>
-                                            <li>Team collaboration features</li>
-                                            <li>Priority support</li>
+                                            <li>Onboarding support</li>
                                         </ul>
                                     </div>
-                                    <a class="button large" href="mailto:hello@pactflow.io">Contact Us</a>
+                                    <a class="button large multiple" href="javascript:void(0)" data-cb-type="checkout" data-cb-plan-id="business-25-plan" >Sign up ($249)</a>
                                 </div>
                             </div>
                         </div>
@@ -110,11 +106,11 @@ signup: true
                                 </div>
                                 <div class="col-xs-4 theader standard">
                                     <div class="ptitle">Team</div>
-                                    <div class="pprice">$29 or $49 / month</div>
+                                    <div class="pprice">$99 / month</div>
                                 </div>
                                 <div class="col-xs-4 theader premium">
                                     <div class="ptitle">Business</div>
-                                    <div class="pprice">$24 per user / month</div>
+                                    <div class="pprice">$249 / month</div>
                                 </div>
                             </div>
                         </div>
@@ -135,22 +131,42 @@ signup: true
                                     <i class="pricing-icon-text">1</i>
                                 </div>
                                 <div class="col-xs-4 col-sm-4 ccfreature standard">
-                                    <i class="pricing-icon-text">5 or 10</i>
+                                    <i class="pricing-icon-text">10</i>
                                 </div>
                                 <div class="col-xs-4 col-sm-4 ccfreature premium">
-                                        <i class="pricing-icon-text">10 - 50</i>
+                                        <i class="pricing-icon-text">25</i>
+                                    </div>
                                 </div>
                             </div>
                         </div>
-                    </div>
-                    <div class="row feature">
-                        <div class="col-xs-12 col-sm-4 cfeature infos">
-                            Contracts
+                        <div class="row feature">
+                                <div class="col-xs-12 col-sm-4 cfeature infos">
+                                    Applications
+                                    <i class="fa fa-info-circle" data-toggle="tooltip" title="An application is anything that communicates via an API. e.g. a Website, API or a lambda function"></i>
+                                </div>
+                                <div class="col-xs-12 col-sm-8">
+                                    <div class="row">
+                                        <div class="col-xs-4 col-sm-4 ccfreature free">
+                                                <i class="pricing-icon-text">Unlimited</i>
+                                        </div>
+                                        <div class="col-xs-4 col-sm-4 ccfreature standard">
+                                                <i class="pricing-icon-text">Unlimited</i>
+                                            </div>
+                                            <div class="col-xs-4 col-sm-4 ccfreature premium">
+                                                <i class="pricing-icon-text">Unlimited</i>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        <div class="row feature">
+                            <div class="col-xs-12 col-sm-4 cfeature infos">
+                                Contracts
+                                <i class="fa fa-info-circle" data-toggle="tooltip" title="Number of integrations between applications"></i>
                         </div>
                         <div class="col-xs-12 col-sm-8">
                             <div class="row">
                                 <div class="col-xs-4 col-sm-4 ccfreature free">
-                                        <i class="pricing-icon-text">2</i>
+                                        <i class="pricing-icon-text">5</i>
                                 </div>
                                 <div class="col-xs-4 col-sm-4 ccfreature standard">
                                         <i class="pricing-icon-text">Unlimited</i>
@@ -181,33 +197,16 @@ signup: true
                     </div>
                     <div class="row feature">
                         <div class="col-xs-12 col-sm-4 cfeature infos">
-                            Swagger Support
-                        </div>
-                        <div class="col-xs-12 col-sm-8">
-                            <div class="row">
-                                <div class="col-xs-4 col-sm-4 ccfreature free">
-                                    <i class="pricing-icon-text">No</i>
-                                </div>
-                                <div class="col-xs-4 col-sm-4 ccfreature standard">
-                                        <i class="pricing-icon-text">No</i>
-                                </div>
-                                <div class="col-xs-4 col-sm-4 ccfreature premium">
-                                    <img src="/assets/img/tick.png" class="pricing-icon" />
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="row feature">
-                        <div class="col-xs-12 col-sm-4 cfeature infos">
                             Test Reporting (Verifications)
                         </div>
                         <div class="col-xs-12 col-sm-8">
                             <div class="row">
                                 <div class="col-xs-4 col-sm-4 ccfreature free">
                                     <i class="pricing-icon-text">No</i>
+                                    <!-- <img src="/assets/img/tick.png" class="pricing-icon" /> -->
                                 </div>
                                 <div class="col-xs-4 col-sm-4 ccfreature standard">
-                                        <i class="pricing-icon-text">No</i>
+                                    <img src="/assets/img/tick.png" class="pricing-icon" />
                                 </div>
                                 <div class="col-xs-4 col-sm-4 ccfreature premium">
                                     <img src="/assets/img/tick.png" class="pricing-icon" />
@@ -251,7 +250,7 @@ signup: true
                                 </div>
                             </div>
                     </div>
-                    <div class="row feature-section">
+                    <!-- <div class="row feature-section">
                         <div class="col-xs-12 col-sm-12">
                             Collaboration
                         </div>
@@ -309,7 +308,7 @@ signup: true
                                 </div>
                             </div>
                         </div>
-                    </div>
+                    </div> -->
                     <div class="row feature-section">
                         <div class="col-xs-12 col-sm-12">
                             Security and Administration
@@ -325,10 +324,10 @@ signup: true
                                     <i class="pricing-icon-text">Forum and help centre</i>
                                 </div>
                                 <div class="col-xs-4 col-sm-4 ccfreature standard">
-                                    <i class="pricing-icon-text">Email and chat</i>
+                                    <i class="pricing-icon-text">Email support</i>
                                 </div>
                                 <div class="col-xs-4 col-sm-4 ccfreature premium">
-                                    <i class="pricing-icon-text">Priority support</i>
+                                    <i class="pricing-icon-text">Email + onboarding support</i>
                                 </div>
                             </div>
                         </div>
@@ -336,6 +335,7 @@ signup: true
                     <div class="row feature">
                         <div class="col-xs-12 col-sm-4 cfeature infos">
                             SAML SSO
+                            <i class="fa fa-info-circle" data-toggle="tooltip" title="Sign-in via your enterprise identity provider such as Okta, Auth0, AD"></i>
                         </div>
                         <div class="col-xs-12 col-sm-8">
                             <div class="row">
@@ -344,6 +344,24 @@ signup: true
                                 </div>
                                 <div class="col-xs-4 col-sm-4 ccfreature standard">
                                         <i class="pricing-icon-text">No</i>
+                                </div>
+                                <div class="col-xs-4 col-sm-4 ccfreature premium">
+                                    <img src="/assets/img/tick.png" class="pricing-icon" />
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row feature">
+                        <div class="col-xs-12 col-sm-4 cfeature infos">
+                                Sign-in via Google apps and GitHub organizations
+                            </div>
+                            <div class="col-xs-12 col-sm-8">
+                                <div class="row">
+                                <div class="col-xs-4 col-sm-4 ccfreature free">
+                                    <i class="pricing-icon-text">No</i>
+                                </div>
+                                <div class="col-xs-4 col-sm-4 ccfreature standard">
+                                    <img src="/assets/img/tick.png" class="pricing-icon" />
                                 </div>
                                 <div class="col-xs-4 col-sm-4 ccfreature premium">
                                     <img src="/assets/img/tick.png" class="pricing-icon" />

--- a/pricing.html
+++ b/pricing.html
@@ -45,14 +45,14 @@ signup: true
                             <!-- /price-block -->
                             <div class="col-md-4 col-lg-4 bgrid">
                                 <div class="price-block primary">
-                                    <div class="top-part" data-info="USD $99 /mth">
+                                    <div class="top-part" data-info="USD $49 or $99 /mth">
                                         <h3 class="plan-title">Team</h3>
                                         <p class="price-txt">For small teams</p>
                                     </div>
                                     <div class="bottom-part">
                                         <p>Great for small development teams and start ups</p>
                                         <ul class="features">
-                                            <li>10 users</li>
+                                            <li>5 or 10 users</li>
                                             <li>Unlimited contracts</li>
                                             <li>Email support</li>
                                             <li>Github and Google Login</li>
@@ -60,7 +60,10 @@ signup: true
                                         <p>Try us for <strong>FREE</strong> for the first 14 days</p>
                                     </div>
                                     <div class="row">
-                                        <a class="button large multiple" href="javascript:void(0)" data-cb-type="checkout" data-cb-plan-id="team-10-plan" >Sign up ($99)</a>
+                                        <a class="button large multiple first" href="javascript:void(0)" data-cb-type="checkout" data-cb-plan-id="team-5-plan" >Sign up for 5 users ($49)</a>
+                                    </div>
+                                    <div class="row">
+                                        <a class="button large multiple" href="javascript:void(0)" data-cb-type="checkout" data-cb-plan-id="team-10-plan" >Sign up for 10 users ($99)</a>
                                     </div>
                                 </div>
                             </div>
@@ -106,7 +109,7 @@ signup: true
                                 </div>
                                 <div class="col-xs-4 theader standard">
                                     <div class="ptitle">Team</div>
-                                    <div class="pprice">$99 / month</div>
+                                    <div class="pprice">$49 or $99 / month</div>
                                 </div>
                                 <div class="col-xs-4 theader premium">
                                     <div class="ptitle">Business</div>
@@ -131,7 +134,7 @@ signup: true
                                     <i class="pricing-icon-text">1</i>
                                 </div>
                                 <div class="col-xs-4 col-sm-4 ccfreature standard">
-                                    <i class="pricing-icon-text">10</i>
+                                    <i class="pricing-icon-text">5 or 10</i>
                                 </div>
                                 <div class="col-xs-4 col-sm-4 ccfreature premium">
                                         <i class="pricing-icon-text">25</i>

--- a/pricing.html
+++ b/pricing.html
@@ -45,14 +45,14 @@ signup: true
                             <!-- /price-block -->
                             <div class="col-md-4 col-lg-4 bgrid">
                                 <div class="price-block primary">
-                                    <div class="top-part" data-info="USD $49 or $99 /mth">
+                                    <div class="top-part" data-info="USD $99 /mth">
                                         <h3 class="plan-title">Team</h3>
                                         <p class="price-txt">For small teams</p>
                                     </div>
                                     <div class="bottom-part">
                                         <p>Great for small development teams and start ups</p>
                                         <ul class="features">
-                                            <li>5 or 10 users</li>
+                                            <li>10 users</li>
                                             <li>Unlimited contracts</li>
                                             <li>Email support</li>
                                             <li>Github and Google Login</li>
@@ -60,10 +60,7 @@ signup: true
                                         <p>Try us for <strong>FREE</strong> for the first 14 days</p>
                                     </div>
                                     <div class="row">
-                                        <a class="button large multiple first" href="javascript:void(0)" data-cb-type="checkout" data-cb-plan-id="team-5-plan" >Sign up for 5 users ($49)</a>
-                                    </div>
-                                    <div class="row">
-                                        <a class="button large multiple" href="javascript:void(0)" data-cb-type="checkout" data-cb-plan-id="team-10-plan" >Sign up for 10 users ($99)</a>
+                                        <a class="button large multiple" href="javascript:void(0)" data-cb-type="checkout" data-cb-plan-id="team-10-plan" >Sign up ($99)</a>
                                     </div>
                                 </div>
                             </div>
@@ -109,7 +106,7 @@ signup: true
                                 </div>
                                 <div class="col-xs-4 theader standard">
                                     <div class="ptitle">Team</div>
-                                    <div class="pprice">$49 or $99 / month</div>
+                                    <div class="pprice">$99 / month</div>
                                 </div>
                                 <div class="col-xs-4 theader premium">
                                     <div class="ptitle">Business</div>
@@ -134,7 +131,7 @@ signup: true
                                     <i class="pricing-icon-text">1</i>
                                 </div>
                                 <div class="col-xs-4 col-sm-4 ccfreature standard">
-                                    <i class="pricing-icon-text">5 or 10</i>
+                                    <i class="pricing-icon-text">10</i>
                                 </div>
                                 <div class="col-xs-4 col-sm-4 ccfreature premium">
                                         <i class="pricing-icon-text">25</i>


### PR DESCRIPTION
* Updates plan ID for team 5
* Updates plan ID for team 10
* Adds business 25 plan
* Developer (free) plan now also provisioned through chargebee, to enable simpler upgrades/downgrades in the future

Changes look as follows:

![screenshot](https://user-images.githubusercontent.com/53900/64903369-9b77d280-d6fa-11e9-997a-8981a5c74c80.png)

![screenshot](https://user-images.githubusercontent.com/53900/64903372-a2064a00-d6fa-11e9-9972-62cd09210e0f.png)

We shouldn't merge this in until https://github.com/pactflow/provision-tenant-service/pull/2 has been completed, and we're happy with finalised pricing etc.