### PR TITLE
chore: migrate pactflow.io website to prod account - step 1

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,6 +5,7 @@ env:
 
 steps:
   - command: |-
+      ./aws/deploy.sh
       ./shell/bundle.sh
       ./shell/deploy.sh
     label: ':rocket: Deploy staging.pactflow.io'
@@ -17,6 +18,7 @@ steps:
       queue: pact-dev
 
   - command: |-
+      ./aws/deploy.sh
       ./shell/bundle.sh
       ./shell/deploy.sh
     label: ':rocket: Deploy staging-www.pactflow.io'
@@ -31,6 +33,7 @@ steps:
   - block: ":rocket: Release!"
 
   - command: |-
+      ./aws/deploy.sh
       ./shell/bundle.sh
       ./shell/deploy.sh
     label: ':rocket: Production Deploy - pactflow.io'
@@ -45,6 +48,7 @@ steps:
   - wait
 
   - command: |-
+      ./aws/deploy.sh
       ./shell/bundle.sh
       ./shell/deploy.sh
     label: ':rocket: Production Deploy - www.pactflow.io'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,6 +14,16 @@ steps:
     agents:
       queue: pact-dev
 
+  - command: |-
+      ./shell/bundle.sh
+      ./shell/deploy.sh
+    label: ':rocket: Deploy staging.pactflow.io'
+    env:
+      JEKYLL_ENV: dev
+      ENVIRONMENT: dev
+    agents:
+      queue: pact
+
   - block: ":rocket: Release!"
 
   - command: |-
@@ -25,4 +35,16 @@ steps:
       ENVIRONMENT: prod
     agents:
       queue: pact-dev
+
+  - wait
+
+  - command: |-
+      ./shell/bundle.sh
+      ./shell/deploy.sh
+    label: ':rocket: Production Deploy - pactflow.io'
+    env:
+      JEKYLL_ENV: prod
+      ENVIRONMENT: prod
+    agents:
+      queue: pact
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,16 +11,20 @@ steps:
     env:
       JEKYLL_ENV: dev
       ENVIRONMENT: dev
+      S3BUCKET_NAME: staging.pactflow.io
+      HOST_NAME: staging.pactflow.io
     agents:
       queue: pact-dev
 
   - command: |-
       ./shell/bundle.sh
       ./shell/deploy.sh
-    label: ':rocket: Deploy staging.pactflow.io'
+    label: ':rocket: Deploy staging-www.pactflow.io'
     env:
       JEKYLL_ENV: dev
       ENVIRONMENT: dev
+      S3BUCKET_NAME: www.staging.pactflow.io
+      HOST_NAME: staging.pactflow.io
     agents:
       queue: pact-prod
 
@@ -33,6 +37,8 @@ steps:
     env:
       JEKYLL_ENV: prod
       ENVIRONMENT: prod
+      S3BUCKET_NAME: pactflow.io
+      HOST_NAME: pactflow.io
     agents:
       queue: pact-dev
 
@@ -41,10 +47,12 @@ steps:
   - command: |-
       ./shell/bundle.sh
       ./shell/deploy.sh
-    label: ':rocket: Production Deploy - pactflow.io'
+    label: ':rocket: Production Deploy - www.pactflow.io'
     env:
       JEKYLL_ENV: prod
       ENVIRONMENT: prod
+      S3BUCKET_NAME: www.pactflow.io
+      HOST_NAME: pactflow.io
     agents:
       queue: pact-prod
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -23,8 +23,8 @@ steps:
       ./shell/deploy.sh
     label: ':rocket: Deploy staging-www.pactflow.io'
     env:
-      JEKYLL_ENV: dev
-      ENVIRONMENT: dev
+      JEKYLL_ENV: staging
+      ENVIRONMENT: staging
       S3BUCKET_NAME: www.staging.pactflow.io
       HOST_NAME: staging.pactflow.io
     agents:
@@ -38,7 +38,7 @@ steps:
       ./shell/deploy.sh
     label: ':rocket: Production Deploy - pactflow.io'
     env:
-      JEKYLL_ENV: prod
+      JEKYLL_ENV: production
       ENVIRONMENT: prod
       S3BUCKET_NAME: pactflow.io
       HOST_NAME: pactflow.io
@@ -53,7 +53,7 @@ steps:
       ./shell/deploy.sh
     label: ':rocket: Production Deploy - www.pactflow.io'
     env:
-      JEKYLL_ENV: prod
+      JEKYLL_ENV: production
       ENVIRONMENT: prod
       S3BUCKET_NAME: www.pactflow.io
       HOST_NAME: pactflow.io

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -22,7 +22,7 @@ steps:
       JEKYLL_ENV: dev
       ENVIRONMENT: dev
     agents:
-      queue: pact
+      queue: pact-prod
 
   - block: ":rocket: Release!"
 
@@ -46,5 +46,5 @@ steps:
       JEKYLL_ENV: prod
       ENVIRONMENT: prod
     agents:
-      queue: pact
+      queue: pact-prod
 

--- a/aws/deploy.sh
+++ b/aws/deploy.sh
@@ -30,7 +30,7 @@ docker run --rm \
     -e AWS_SESSION_TOKEN \
     -e AWS_PROFILE \
     -e AWS_DEFAULT_REGION \
-    ${STACKUP_DOCKER_IMAGE} "${STACK_NAME}" up -t ${TEMPLATE} \
+    ${STACKUP_DOCKER_IMAGE} "${STACK_NAME}" up -t aws/${TEMPLATE} \
     -o S3Bucket=${S3BUCKET_NAME} \
     -o HostName=${HOST_NAME} \
     -o Environment=${ENVIRONMENT}

--- a/aws/deploy.sh
+++ b/aws/deploy.sh
@@ -31,7 +31,8 @@ docker run --rm \
     -e AWS_PROFILE \
     -e AWS_DEFAULT_REGION \
     ${STACKUP_DOCKER_IMAGE} "${STACK_NAME}" up -t ${TEMPLATE} \
-    -p parameters.${ENVIRONMENT}.yml \
+    -o S3Bucket=${S3BUCKET_NAME} \
+    -o HostName=${HOST_NAME} \
     -o Environment=${ENVIRONMENT}
 
 log "Done."

--- a/aws/template.yaml
+++ b/aws/template.yaml
@@ -10,6 +10,9 @@ Parameters:
     Description: HostedZone to attach the domain to
     Type: String
     Default: Z2KANQBPTUQA1W #pactflow.io
+  S3Bucket:
+    Description: S3 Bucket to host the website
+    Type: String
   HostName:
     Description: Domain name to host the website on
     Type: String
@@ -24,7 +27,7 @@ Resources:
         Type: AWS::S3::Bucket
         Properties:
            AccessControl: PublicRead
-           BucketName: !Ref HostName
+           BucketName: !Ref S3Bucket
            WebsiteConfiguration:
               ErrorDocument: 404.html
               IndexDocument: index.html

--- a/shell/deploy.sh
+++ b/shell/deploy.sh
@@ -4,13 +4,9 @@ set -e
 
 export ENVIRONMENT
 export JEKYLL_ENV
+export S3BUCKET_NAME
 
-if [ "${ENVIRONMENT}" == "dev" ]; then
-  AWS_S3_BUCKET="s3://staging.pactflow.io"
-else
-  AWS_S3_BUCKET="s3://pactflow.io"
-fi
-
+AWS_S3_BUCKET="s3://${S3BUCKET_NAME}"
 ./shell/build.sh
 
 aws s3 sync ./public/ $AWS_S3_BUCKET \


### PR DESCRIPTION
* Create a duplicate deployment of the pactflow website in prod for
  easier switchover