### PR TITLE
fix: point to 404 page for 4xx responses

### DIFF
--- a/aws/template.yaml
+++ b/aws/template.yaml
@@ -48,6 +48,16 @@ Resources:
                         HTTPPort: '80'
                         HTTPSPort: '443'
                         OriginProtocolPolicy: http-only
+                CustomErrorResponses:
+                    - ErrorCode: 401
+                      ResponseCode: 404
+                      ResponsePagePath: /404/index.html
+                    - ErrorCode: 403
+                      ResponseCode: 404
+                      ResponsePagePath: /404/index.html
+                    - ErrorCode: 404
+                      ResponseCode: 404
+                      ResponsePagePath: /404/index.html
                 Enabled: 'true'
                 DefaultCacheBehavior:
                     ForwardedValues:


### PR DESCRIPTION
Because we're _professionals_:

<img width="835" alt="Screen Shot 2019-12-09 at 6 16 47 pm" src="https://user-images.githubusercontent.com/53900/70415142-152c1c00-1ab0-11ea-9c0d-3d797208ceb5.png">

404 page could do with some uplift, but it's not terrible:

<img width="1306" alt="Screen Shot 2019-12-09 at 6 15 20 pm" src="https://user-images.githubusercontent.com/53900/70415120-08a7c380-1ab0-11ea-879d-6130cedd98a6.png">

Note, this should still work with the new website upgrade, assuming there is a `404/index.html` page there at the end of it. If not, we just need to do the update.